### PR TITLE
Remove deprecation warning in ansible 2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-sudo_defaults:
+sudo_defaults_base:
   - "!requiretty"
   - "!visiblepw"
   - always_set_home
@@ -7,6 +7,9 @@ sudo_defaults:
   - env_reset
   - env_keep+=SSH_AUTH_SOCK
   - secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+sudo_defaults_extend: []
+sudo_defaults: "{{ sudo_defaults_base + sudo_defaults_extend }}"
+
 sudo_sudoers:
   - name: "%sudo"
     nopasswd: true

--- a/tasks/sudo.yml
+++ b/tasks/sudo.yml
@@ -23,5 +23,5 @@
 
 - name: sudo | Create sudoers.d files
   template: src=sudoers.d.j2 dest="/etc/sudoers.d/{{ item.name }}" mode=0440 owner=root group=root validate="/usr/sbin/visudo -cf %s"
-  with_items: sudo_sudoers_d
+  with_items: "{{sudo_sudoers_d}}"
   tags: sudo


### PR DESCRIPTION
`[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{sudo_sudoers_d}}').`
